### PR TITLE
feat: add multi-location inventory and voice input

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,10 +5,14 @@ import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import Dashboard from "@/pages/dashboard";
 import NotFound from "@/pages/not-found";
+import VoiceInput from "@/pages/voice-input";
+import Locations from "@/pages/locations";
 
 function Router() {
   return (
     <Switch>
+      <Route path="/voice" component={VoiceInput} />
+      <Route path="/locations" component={Locations} />
       <Route path="/" component={Dashboard} />
       <Route component={NotFound} />
     </Switch>

--- a/client/src/hooks/use-voice-recognition.tsx
+++ b/client/src/hooks/use-voice-recognition.tsx
@@ -1,5 +1,14 @@
 import { useState, useRef, useCallback } from 'react';
 
+// Minimal type declarations for speech recognition
+type SpeechRecognition = any;
+declare global {
+  interface Window {
+    SpeechRecognition: any;
+    webkitSpeechRecognition: any;
+  }
+}
+
 interface UseVoiceRecognitionProps {
   onResult: (transcript: string, confidence?: number) => void;
   onEnd: () => void;
@@ -47,7 +56,7 @@ export function useVoiceRecognition({
       setIsListening(true);
     };
 
-    recognition.onresult = (event) => {
+    recognition.onresult = (event: any) => {
       let interimTranscript = '';
       let latestConfidence = 0;
 
@@ -68,7 +77,7 @@ export function useVoiceRecognition({
       onResult(currentTranscript, latestConfidence);
     };
 
-    recognition.onerror = (event) => {
+    recognition.onerror = (event: any) => {
       console.error('Speech recognition error:', event.error);
       setIsListening(false);
       onError(`Speech recognition error: ${event.error}`);

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -10,11 +10,12 @@ import LowStockAlerts from "@/components/low-stock-alerts";
 import RecentActivity from "@/components/recent-activity";
 import { useWebSocket } from "@/hooks/use-websocket";
 import { useState, useEffect } from "react";
+import { Link } from "wouter";
 
 export default function Dashboard() {
   const [isVoiceModalOpen, setIsVoiceModalOpen] = useState(false);
   
-  const { data: dashboardData, isLoading, refetch } = useQuery({
+  const { data: dashboardData, isLoading, refetch } = useQuery<any>({
     queryKey: ["/api/dashboard"],
     refetchInterval: 30000, // Refetch every 30 seconds
   });
@@ -54,7 +55,9 @@ export default function Dashboard() {
           </div>
           <div>
             <h1 className="text-xl font-bold" data-testid="app-title">IritoDeVoice</h1>
-            <p className="text-sm opacity-90" data-testid="location">東京倉庫A</p>
+            <Link href="/locations">
+              <p className="text-sm opacity-90 underline" data-testid="location">東京倉庫A</p>
+            </Link>
           </div>
         </div>
         <div className="flex items-center space-x-3">

--- a/client/src/pages/locations.tsx
+++ b/client/src/pages/locations.tsx
@@ -1,0 +1,91 @@
+import { useState, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "wouter";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import type { Product } from "@shared/schema";
+
+export default function Locations() {
+  const { data: locationsData } = useQuery<{ locations: string[] }>({
+    queryKey: ["/api/locations"],
+  });
+  const locations = locationsData?.locations || [];
+  const [selected, setSelected] = useState<string>("");
+
+  useEffect(() => {
+    if (!selected && locations.length > 0) {
+      setSelected(locations[0]);
+    }
+  }, [locations, selected]);
+
+  const { data: products } = useQuery<Product[]>({
+    queryKey: ["/api/locations", encodeURIComponent(selected), "products"],
+    enabled: !!selected,
+  });
+
+  return (
+    <div className="max-w-md mx-auto gradient-bg min-h-screen relative overflow-hidden">
+      <header className="flex items-center justify-between p-6 pt-16 text-white">
+        <div className="flex items-center space-x-4">
+          <Link href="/">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-12 h-12 bg-white/20 backdrop-blur-sm rounded-2xl flex items-center justify-center border border-white/30 text-white hover:bg-white/30"
+            >
+              <ArrowLeft className="text-xl" />
+            </Button>
+          </Link>
+          <div>
+            <h1 className="text-xl font-bold">拠点在庫</h1>
+            <p className="text-sm opacity-90">拠点別在庫一覧</p>
+          </div>
+        </div>
+      </header>
+
+      <div className="px-6 pb-6">
+        {locations.length > 0 && (
+          <select
+            className="w-full mb-4 p-3 rounded-lg text-gray-800"
+            value={selected}
+            onChange={(e) => setSelected(e.target.value)}
+            data-testid="location-select"
+          >
+            {locations.map((loc) => (
+              <option key={loc} value={loc}>
+                {loc}
+              </option>
+            ))}
+          </select>
+        )}
+
+        {products && (
+          <Card className="bg-white/20 backdrop-blur-sm border border-white/30 rounded-3xl p-4" data-testid="location-inventory">
+            <table className="w-full text-white text-sm">
+              <thead>
+                <tr className="text-left">
+                  <th className="pb-2">商品名</th>
+                  <th className="pb-2">コード</th>
+                  <th className="pb-2 text-right">在庫</th>
+                </tr>
+              </thead>
+              <tbody>
+                {products.map((p) => (
+                  <tr key={p.id} className="border-t border-white/20">
+                    <td className="py-2">{p.name}</td>
+                    <td className="py-2">{p.code}</td>
+                    <td className="py-2 text-right">
+                      {p.currentStock}
+                      {p.unit}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/voice-input.tsx
+++ b/client/src/pages/voice-input.tsx
@@ -2,16 +2,22 @@ import { PackageIcon, ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import VoiceDisplay from "@/components/voice-display";
 import { Link } from "wouter";
+import { useState } from "react";
 
 export default function VoiceInput() {
+  const [isOpen, setIsOpen] = useState(true);
+
+  const handleClose = () => setIsOpen(false);
+  const handleOpen = () => setIsOpen(true);
+
   return (
     <div className="max-w-md mx-auto gradient-bg min-h-screen relative overflow-hidden">
       {/* Header */}
       <header className="flex items-center justify-between p-6 pt-16 text-white" data-testid="voice-header">
         <div className="flex items-center space-x-4">
           <Link href="/">
-            <Button 
-              variant="ghost" 
+            <Button
+              variant="ghost"
               size="sm"
               className="w-12 h-12 bg-white/20 backdrop-blur-sm rounded-2xl flex items-center justify-center border border-white/30 text-white hover:bg-white/30"
               data-testid="back-button"
@@ -31,7 +37,16 @@ export default function VoiceInput() {
 
       {/* Main Content */}
       <div className="px-6 pb-6">
-        <VoiceDisplay />
+        {!isOpen && (
+          <Button
+            onClick={handleOpen}
+            className="w-full bg-primary text-white py-3 rounded-xl font-medium"
+            data-testid="voice-start-button"
+          >
+            音声入力開始
+          </Button>
+        )}
+        <VoiceDisplay isOpen={isOpen} onClose={handleClose} />
       </div>
     </div>
   );

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -75,6 +75,26 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Get products by location
+  app.get("/api/locations/:location/products", async (req, res) => {
+    try {
+      const products = await storage.getProductsByLocation(req.params.location);
+      res.json(products);
+    } catch (error) {
+      res.status(500).json({ error: "Failed to fetch products for location" });
+    }
+  });
+
+  // Get list of locations
+  app.get("/api/locations", async (req, res) => {
+    try {
+      const locations = await storage.getLocations();
+      res.json({ locations });
+    } catch (error) {
+      res.status(500).json({ error: "Failed to fetch locations" });
+    }
+  });
+
   // Get product by code
   app.get("/api/products/code/:code", async (req, res) => {
     try {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -18,6 +18,8 @@ export interface IStorage {
   createProduct(product: InsertProduct): Promise<Product>;
   updateProduct(id: string, updates: Partial<Product>): Promise<Product | undefined>;
   updateProductStock(id: string, newStock: number): Promise<Product | undefined>;
+  getProductsByLocation(location: string): Promise<Product[]>;
+  getLocations(): Promise<string[]>;
   
   // Transactions
   getTransactions(limit?: number): Promise<InventoryTransaction[]>;
@@ -146,7 +148,7 @@ export class MemStorage implements IStorage {
       ...insertProduct,
       id,
       lastUpdated: new Date(),
-    };
+    } as Product;
     this.products.set(id, product);
     return product;
   }
@@ -164,6 +166,16 @@ export class MemStorage implements IStorage {
     return this.updateProduct(id, { currentStock: newStock });
   }
 
+  async getProductsByLocation(location: string): Promise<Product[]> {
+    return Array.from(this.products.values()).filter(p => p.location === location);
+  }
+
+  async getLocations(): Promise<string[]> {
+    const locations = new Set<string>();
+    this.products.forEach(p => locations.add(p.location));
+    return Array.from(locations);
+  }
+
   async getTransactions(limit = 50): Promise<InventoryTransaction[]> {
     return this.transactions
       .sort((a, b) => (b.timestamp?.getTime() || 0) - (a.timestamp?.getTime() || 0))
@@ -176,7 +188,7 @@ export class MemStorage implements IStorage {
       ...insertTransaction,
       id,
       timestamp: new Date(),
-    };
+    } as InventoryTransaction;
     this.transactions.push(transaction);
     
     // Update today's KPIs
@@ -200,7 +212,7 @@ export class MemStorage implements IStorage {
       ...insertCommand,
       id,
       timestamp: new Date(),
-    };
+    } as VoiceCommand;
     this.voiceCommands.push(command);
     
     // Update voice commands count for today


### PR DESCRIPTION
## Summary
- add storage helpers and API routes for location-based inventory queries
- create locations page and link from dashboard
- enhance voice input page and routing with basic speech types

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b9cbdf2d40832483e2d09aae6e8ee1