### PR TITLE
Add reorder point management dashboard

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,12 +7,14 @@ import Dashboard from "@/pages/dashboard";
 import NotFound from "@/pages/not-found";
 import VoiceInput from "@/pages/voice-input";
 import Locations from "@/pages/locations";
+import ReorderDashboard from "@/pages/reorder-dashboard";
 
 function Router() {
   return (
     <Switch>
       <Route path="/voice" component={VoiceInput} />
       <Route path="/locations" component={Locations} />
+      <Route path="/reorder" component={ReorderDashboard} />
       <Route path="/" component={Dashboard} />
       <Route component={NotFound} />
     </Switch>

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -115,10 +115,12 @@ export default function Dashboard() {
             <Home className="text-xl" />
             <span className="text-xs font-semibold">ホーム</span>
           </Button>
-          <Button variant="ghost" className="flex flex-col items-center space-y-1 text-gray-400 p-2" data-testid="nav-analytics">
-            <BarChart3 className="text-xl" />
-            <span className="text-xs font-medium">分析</span>
-          </Button>
+          <Link href="/reorder">
+            <Button variant="ghost" className="flex flex-col items-center space-y-1 text-gray-400 p-2" data-testid="nav-analytics">
+              <BarChart3 className="text-xl" />
+              <span className="text-xs font-medium">分析</span>
+            </Button>
+          </Link>
           <Button
             onClick={handleOpenVoiceModal}
             className="w-16 h-16 bg-gradient-to-r from-purple-600 to-blue-500 rounded-3xl flex items-center justify-center shadow-xl transform hover:scale-105 transition-transform"

--- a/client/src/pages/reorder-dashboard.tsx
+++ b/client/src/pages/reorder-dashboard.tsx
@@ -1,0 +1,81 @@
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Home } from "lucide-react";
+import { Link } from "wouter";
+import type { Product } from "@shared/schema";
+
+export default function ReorderDashboard() {
+  const { data: products, isLoading } = useQuery<Product[]>({
+    queryKey: ["/api/products"],
+  });
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen gradient-bg flex items-center justify-center">
+        <div className="text-white text-lg">発注点データを読み込み中...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-md mx-auto gradient-bg min-h-screen relative overflow-hidden">
+      {/* Header */}
+      <header className="flex items-center justify-between p-6 pt-16 text-white" data-testid="header">
+        <div className="flex items-center space-x-4">
+          <Link href="/">
+            <Button variant="ghost" size="icon" className="text-white hover:bg-white/20">
+              <Home className="h-6 w-6" />
+            </Button>
+          </Link>
+          <div>
+            <h1 className="text-xl font-bold" data-testid="page-title">発注点管理</h1>
+            <p className="text-sm opacity-90" data-testid="page-subtitle">在庫と発注点の一覧</p>
+          </div>
+        </div>
+      </header>
+
+      {/* Reorder Table */}
+      <div className="px-6 pb-6" data-testid="reorder-table">
+        <Card className="bg-white/20 backdrop-blur-sm border border-white/30 rounded-3xl">
+          <CardContent className="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow className="text-white">
+                  <TableHead className="text-white">商品</TableHead>
+                  <TableHead className="text-white">在庫</TableHead>
+                  <TableHead className="text-white">発注点</TableHead>
+                  <TableHead className="text-white">状態</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(products || []).map((p) => (
+                  <TableRow key={p.id} className="text-white">
+                    <TableCell className="font-medium">{p.name}</TableCell>
+                    <TableCell>
+                      {p.currentStock}
+                      {p.unit}
+                    </TableCell>
+                    <TableCell>
+                      {p.minStock}
+                      {p.unit}
+                    </TableCell>
+                    <TableCell>
+                      {p.currentStock <= p.minStock ? (
+                        <span className="text-red-400 font-bold">要発注</span>
+                      ) : (
+                        <span className="text-green-400">十分</span>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Add a ReorderDashboard page that lists stock levels against reorder points and highlights items needing replenishment
- Expose the new dashboard at `/reorder` and link to it from the bottom navigation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bcd83e0d50832487051cca034970ae