### PR TITLE
Add manual page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,12 +7,14 @@ import Dashboard from "@/pages/dashboard";
 import NotFound from "@/pages/not-found";
 import VoiceInput from "@/pages/voice-input";
 import Locations from "@/pages/locations";
+import Manual from "@/pages/manual";
 
 function Router() {
   return (
     <Switch>
       <Route path="/voice" component={VoiceInput} />
       <Route path="/locations" component={Locations} />
+      <Route path="/manual" component={Manual} />
       <Route path="/" component={Dashboard} />
       <Route component={NotFound} />
     </Switch>

--- a/client/src/pages/manual.tsx
+++ b/client/src/pages/manual.tsx
@@ -1,0 +1,41 @@
+import { Link } from "wouter";
+
+export default function Manual() {
+  return (
+    <div className="min-h-screen p-6 space-y-4">
+      <header>
+        <h1 className="text-2xl font-bold">作業マニュアル</h1>
+        <p className="text-sm text-muted-foreground">
+          ここではアプリの基本的な使い方を説明します。
+        </p>
+      </header>
+
+      <section className="space-y-2">
+        <h2 className="text-xl font-semibold">在庫の確認</h2>
+        <p>
+          ダッシュボードでは現在の在庫状況をグラフで確認できます。低在庫のアラートにも注意してください。
+        </p>
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="text-xl font-semibold">音声入力</h2>
+        <p>
+          画面下部のマイクボタンを押すと音声入力モードになります。音声で商品情報を追加・更新できます。
+        </p>
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="text-xl font-semibold">ロケーションの変更</h2>
+        <p>
+          ヘッダーの倉庫名をクリックすると、拠点の変更ができます。
+        </p>
+      </section>
+
+      <div>
+        <Link href="/">
+          <a className="text-blue-500 underline">ホームに戻る</a>
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Manual page with basic usage instructions
- wire `/manual` route into app router

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bcd84ad1d4832489084ba44fb582d3